### PR TITLE
Readd Google Images as legacy option

### DIFF
--- a/ReverseImageSearch/build.gradle.kts
+++ b/ReverseImageSearch/build.gradle.kts
@@ -1,6 +1,8 @@
-version = "1.0.3"
+version = "1.0.4"
 description = "A plugin that adds a button for reverse image searching a sent image."
 aliucord.changelog.set("""
+	# Version 1.0.4
+    * Readd google images as option, it started working again (thanks Delphox)
     # Version 1.0.3
     * Replace google images search with google lens, as the old images URL no longer works (thanks Delphox)
     # Version 1.0.2

--- a/ReverseImageSearch/src/main/kotlin/tech/tyman/plugins/reverseimagesearch/ReverseImageSearch.kt
+++ b/ReverseImageSearch/src/main/kotlin/tech/tyman/plugins/reverseimagesearch/ReverseImageSearch.kt
@@ -63,6 +63,7 @@ class ReverseImageSearch : Plugin() {
 enum class Engine(val urlTemplate: String?, val niceName: String) {
     ASK(null, "Ask every time"),
     GOOGLE("https://lens.google.com/uploadbyurl?url=%s", "Google Lens"),
+    GOOGLE_LEGACY("https://www.google.com/searchbyimage?client=app&image_url=%s", "Google Images (legacy)"),
     TIN_EYE("https://www.tineye.com/search?url=%s", "TinEye"),
     YANDEX("https://yandex.com/images/search?url=%s&rpt=imageview", "Yandex"),
     BING("https://www.bing.com/images/search?q=imgurl:%s&view=detailv2&iss=sbi&FORM=IRSBIQ", "Bing"),


### PR DESCRIPTION
So it turns out old Google Images started working again a while ago. Given their difference in result quality (started noticing more and more when using Lens that its just worse) and some people's preference to the old one, it's a good idea to have both Lens and Old Images available but labeling Images as legacy so ppl aren't surprised if it randomly breaks.