### PR TITLE
Use INTENT_IMAGE_URL for image URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -25,12 +25,11 @@ jobs:
           ref: "builds"
           path: "builds"
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: zulu
-          cache: gradle
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/ReverseImageSearch/build.gradle.kts
+++ b/ReverseImageSearch/build.gradle.kts
@@ -1,6 +1,8 @@
-version = "1.0.3"
+version = "1.0.4"
 description = "A plugin that adds a button for reverse image searching a sent image."
 aliucord.changelog.set("""
+    # Version 1.0.4
+    * Fix reverse searching not working on expired discord urls and images inside embeds (thanks Delphox)
     # Version 1.0.3
     * Replace google images search with google lens, as the old images URL no longer works (thanks Delphox)
     # Version 1.0.2

--- a/ReverseImageSearch/src/main/kotlin/tech/tyman/plugins/reverseimagesearch/ReverseImageSearch.kt
+++ b/ReverseImageSearch/src/main/kotlin/tech/tyman/plugins/reverseimagesearch/ReverseImageSearch.kt
@@ -41,7 +41,7 @@ class ReverseImageSearch : Plugin() {
             val btnId = Utils.getResId("menu_media_browser", "id")
             val btn = Utils.appActivity.findViewById<ActionMenuItemView>(btnId)
             btn.setOnLongClickListener {
-                val url = mostRecentIntent.getStringExtra("INTENT_MEDIA_URL") ?: return@setOnLongClickListener false
+                val url = mostRecentIntent.getStringExtra("INTENT_IMAGE_URL") ?: return@setOnLongClickListener false
                 if (settings.engine == Engine.ASK) {
                     EngineSheet(url)
                         .show(Utils.appActivity.supportFragmentManager, "Reverse Image Search")


### PR DESCRIPTION
This fixes issues such as not working on expired/stripped Discord media urls, and also images inside of embeds (eg. Fxtwitter). As a benefit it also works on Tenor links now.

Also updates workflow.